### PR TITLE
Fix OpenVAS script id matching

### DIFF
--- a/plugins/testing/scan/openvas_plugin/setup.py
+++ b/plugins/testing/scan/openvas_plugin/setup.py
@@ -38,7 +38,7 @@ except ImportError:
     import pickle as Pickler
 
 # Global regex
-REGEX_PLUGIN_ID = re.compile(r'(script_[o]*id[\s]*\([\s]*)([\d\w]+)([\s]*\)[\s]*);')
+REGEX_PLUGIN_ID = re.compile(r'(?:SCRIPT_OID|script_[o]*id)[^\d]+(?:(?:\d+.){9})?(\d+)\'?\"?\)?(?:\s+)?;')
 
 # Custom Types
 RulePack = namedtuple("RulePack", ["rules", "rule_index"])
@@ -291,22 +291,11 @@ def get_script_id(text):
     r = REGEX_PLUGIN_ID.search(text)
 
     if r:
-        if len(r.groups()) == 3:
-            info = r.group(2)
-
-            # Numeric format -> script_id(12299);
+        if len(r.groups()) == 1:
             try:
-                return int(info)
+                return int(r.group(1))
             except ValueError:
-                # Variable references -> script_oid(SCRIPT_OID);
-                tmp_regex = r'''(%s[\s]*\=[\s]*[\"\'])([\.\d]+)([\s]*[\"\'][\s]*;)''' % info
-
-                r2 = re.search(tmp_regex, text)
-                if len(r2.groups()) == 3:
-                    info2 = r2.group(2)
-                    return int(info2.split(".")[-1])
-        else:
-            raise ValueError("Incorrect regex to find ID in plugin.")
+                raise ValueError("Incorrect regex to find ID in plugin.")
 
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Currently it is not possible to generate a database against the latest openvas-nvt-feed-current.tar.bz2.
It also seemed to be missing a lot of files.

Updated matching code to extract the script id in all files.

Regex: 

```
(?:SCRIPT_OID|script_[o]*id)[^\d]+(?:(?:\d+.){9})?(\d+)\'?\"?\)?(?:\s+)?;
```

![Regular expression visualization](https://www.debuggex.com/i/f3CY6duo_mr1mmi_.png)

Cases:

```
SCRIPT_OID = "1.3.6.1.4.1.25623.1.0.900569";
SCRIPT_OID  = "1.3.6.1.4.1.25623.1.0.900569";
script_oid("1.3.6.1.4.1.25623.1.0.900808");
script_oid("1.3.6.1.4.1.25623.1.0.900808") ;
script_oid("900808");
script_oid(900808);
script_oid('900808');
script_oid('900808') ;
script_id('900808');
script_id('900808') ;
```

[Debuggex Demo](https://www.debuggex.com/r/f3CY6duo_mr1mmi_)
