### PR TITLE
Nmap argument deprecated fix

### DIFF
--- a/plugins/testing/scan/nmap.golismero
+++ b/plugins/testing/scan/nmap.golismero
@@ -15,4 +15,4 @@ Class  = NmapScanPlugin
 
 # For now we'll just accept a command line verbatim.
 # In a future version we should "understand" all options instead.
-args = -vv -A -P0
+args = -vv -A -Pn


### PR DESCRIPTION
The -P0 option of nmap is deprecated. Please use -Pn