### PR TITLE
Correction of errors in report generation

### DIFF
--- a/plugins/testing/scan/openvas.py
+++ b/plugins/testing/scan/openvas.py
@@ -416,14 +416,14 @@ class OpenVASPlugin(TestingPlugin):
                             description = None
 
                 # Extract the CVEs and Bugtraq IDs.
-                cve = nvt.cve.split(", ") if nvt.cve else []
+                cve = nvt.cve if nvt.cve else []
                 if "NOCVE" in cve:
                     cve.remove("NOCVE")
                 bid = []
                 if nvt.bid:
-                    bid.extend("BID-" + x for x in nvt.bid.split(", "))
+                    bid.extend("BID-" + x for x in nvt.bid)
                 if nvt.bugtraq:
-                    bid.extend("BID-" + x for x in nvt.bugtraq.split(", "))
+                    bid.extend("BID-" + x for x in nvt.bugtraq)
                 if "NOBID" in bid:
                     cve.remove("NOBID")
 


### PR DESCRIPTION
[!] OpenVAS: Error parsing OpenVAS results: 'list' object has no attribute 'split'
[!] OpenVAS: Traceback (most recent call last):
  File "/usr/local/golismero/plugins/testing/scan/openvas.py", line 419, in parse_results                                                                                
    cve = nvt.cve.split(", ") if nvt.cve else []
AttributeError: 'list' object has no attribute 'split'