### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ git clone https://github.com/golismero/golismero.git
 cd golismero
 pip install -r requirements.txt
 pip install -r requirements_unix.txt
-ln -s /opt/golismero/golismero.py /usr/bin/golismero
+ln -s /opt/golismero/golismero.py /usr/local/bin/golismero
 exit
 ```
 


### PR DESCRIPTION
I noticed newer versions of MacOSX dont like it when you try to make symlinks into /usr/bin/ but it doesnt complain when you put it in /usr/local/bin
```
ln -s /opt/golismero/golismero.py /usr/bin/golismero
ln: /usr/bin/golismero: Operation not permitted

 golismero.py --help
bash: /usr/local/bin/golismero.py: /usr/local/opt/python/bin/python3.7: bad interpreter: No such file or directory
```